### PR TITLE
Improve exception handling when adding artifacts

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.util
 
+import org.apache.spark.SparkRuntimeException
 import java.nio.file.{Path, Paths}
 
 object ArtifactUtils {
@@ -39,5 +40,18 @@ object ArtifactUtils {
 
   private[sql] def concatenatePaths(basePath: Path, otherPath: String): Path = {
     concatenatePaths(basePath, Paths.get(otherPath))
+  }
+
+  /**
+   * Converts a sequence of exceptions into a single exception by adding all but the first
+   * exceptions as suppressed exceptions to the first one.
+   * @param exceptions
+   * @return
+   */
+  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]): SparkRuntimeException = {
+    require(exceptions.nonEmpty)
+    val mainException = exceptions.head
+    exceptions.drop(1).foreach(mainException.addSuppressed)
+    mainException
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
@@ -49,8 +49,8 @@ object ArtifactUtils {
    * @param exceptions
    * @return
    */
-  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]):
-      SparkRuntimeException = {
+  private[sql] def mergeExceptionsWithSuppressed(
+      exceptions: Seq[SparkRuntimeException]): SparkRuntimeException = {
     require(exceptions.nonEmpty)
     val mainException = exceptions.head
     exceptions.drop(1).foreach(mainException.addSuppressed)

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArtifactUtils.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.sql.util
 
-import org.apache.spark.SparkRuntimeException
 import java.nio.file.{Path, Paths}
+
+import org.apache.spark.SparkRuntimeException
 
 object ArtifactUtils {
 
@@ -48,7 +49,8 @@ object ArtifactUtils {
    * @param exceptions
    * @return
    */
-  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]): SparkRuntimeException = {
+  private[sql] def mergeExceptionsWithSuppressed(exceptions: Seq[SparkRuntimeException]):
+      SparkRuntimeException = {
     require(exceptions.nonEmpty)
     val mainException = exceptions.head
     exceptions.drop(1).foreach(mainException.addSuppressed)

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -135,9 +135,7 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
     }.toSeq
 
     if (failedArtifactExceptions.nonEmpty) {
-      val exception = failedArtifactExceptions.head
-      failedArtifactExceptions.drop(1).foreach(exception.addSuppressed(_))
-      throw exception
+      throw ArtifactUtils.mergeExceptionsWithSuppressed(failedArtifactExceptions.toSeq)
     }
 
     summaries

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.connect.ResourceHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ThreadUtils
 
-class AddArtifactsHandlerSuite extends SharedSparkSession  with ResourceHelper {
+class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
 
   private val CHUNK_SIZE: Int = 32 * 1024
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -32,17 +32,19 @@ import io.grpc.StatusRuntimeException
 import io.grpc.protobuf.StatusProto
 import io.grpc.stub.StreamObserver
 
+import org.apache.spark.SparkRuntimeException
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse}
 import org.apache.spark.sql.connect.ResourceHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ThreadUtils
 
-class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
+class AddArtifactsHandlerSuite extends SharedSparkSession  with ResourceHelper {
 
   private val CHUNK_SIZE: Int = 32 * 1024
 
   private val sessionId = UUID.randomUUID.toString()
+  private val sessionKey = SessionKey("c1", sessionId)
 
   class DummyStreamObserver(p: Promise[AddArtifactsResponse])
       extends StreamObserver[AddArtifactsResponse] {
@@ -51,17 +53,31 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     override def onCompleted(): Unit = {}
   }
 
-  class TestAddArtifactsHandler(responseObserver: StreamObserver[AddArtifactsResponse])
+  class TestAddArtifactsHandler(responseObserver: StreamObserver[AddArtifactsResponse],
+                                throwIfArtifactExists: Boolean = false)
       extends SparkConnectAddArtifactsHandler(responseObserver) {
 
     // Stop the staged artifacts from being automatically deleted
     override protected def cleanUpStagedArtifacts(): Unit = {}
 
     private val finalArtifacts = mutable.Buffer.empty[String]
+    private val artifactChecksums: mutable.Map[String, Long] = mutable.Map.empty
 
     // Record the artifacts that are sent out for final processing.
     override protected def addStagedArtifactToArtifactManager(artifact: StagedArtifact): Unit = {
+      // Throw if artifact already exists and has different checksum
+      // This mocks the behavior of ArtifactManager.addArtifact without comparing the entire file
+      if (throwIfArtifactExists
+          && finalArtifacts.contains(artifact.name)
+          && artifact.getCrc != artifactChecksums(artifact.name)) {
+        throw new SparkRuntimeException(
+          "ARTIFACT_ALREADY_EXISTS",
+          Map("normalizedRemoteRelativePath" -> artifact.name)
+        )
+      }
+
       finalArtifacts.append(artifact.name)
+      artifactChecksums += (artifact.name -> artifact.getCrc)
     }
 
     def getFinalArtifacts: Seq[String] = finalArtifacts.toSeq
@@ -418,4 +434,80 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     }
   }
 
+
+  def addSingleChunkArtifact(
+      handler: SparkConnectAddArtifactsHandler,
+      sessionKey: SessionKey,
+      name: String,
+      artifactPath: Path): Unit = {
+    val dataChunks = getDataChunks(artifactPath)
+    assert(dataChunks.size == 1)
+    val bytes = dataChunks.head
+    val context = proto.UserContext
+      .newBuilder()
+      .setUserId(sessionKey.userId)
+      .build()
+    val fileNameNoExtension = artifactPath.getFileName.toString.split('.').head
+    val singleChunkArtifact = proto.AddArtifactsRequest.SingleChunkArtifact
+      .newBuilder()
+      .setName(name)
+      .setData(
+        proto.AddArtifactsRequest.ArtifactChunk
+          .newBuilder()
+          .setData(bytes)
+          .setCrc(getCrcValues(crcPath.resolve(fileNameNoExtension + ".txt")).head)
+          .build())
+      .build()
+
+    val singleChunkArtifactRequest = AddArtifactsRequest
+      .newBuilder()
+      .setSessionId(sessionKey.sessionId)
+      .setUserContext(context)
+      .setBatch(
+        proto.AddArtifactsRequest.Batch.newBuilder().addArtifacts(singleChunkArtifact).build())
+      .build()
+
+    handler.onNext(singleChunkArtifactRequest)
+  }
+
+  test("All artifacts are added, even if some fail") {
+    val promise = Promise[AddArtifactsResponse]()
+    val handler = new TestAddArtifactsHandler(new DummyStreamObserver(promise),
+                                              throwIfArtifactExists = true)
+    try {
+      val name1 = "jars/dummy1.jar"
+      val name2 = "jars/dummy2.jar"
+      val name3 = "jars/dummy3.jar"
+
+      val artifactPath1 = inputFilePath.resolve("smallClassFile.class")
+      val artifactPath2 = inputFilePath.resolve("smallJar.jar")
+
+      assume(artifactPath1.toFile.exists)
+      addSingleChunkArtifact(handler, sessionKey, name1, artifactPath1)
+      addSingleChunkArtifact(handler, sessionKey, name3, artifactPath1)
+
+      val e = intercept[StatusRuntimeException] {
+        addSingleChunkArtifact(handler, sessionKey, name1, artifactPath2)
+        addSingleChunkArtifact(handler, sessionKey, name2, artifactPath1)
+        addSingleChunkArtifact(handler, sessionKey, name3, artifactPath2)
+        handler.onCompleted()
+      }
+
+      // Both artifacts should be added, despite exception
+      assert(handler.getFinalArtifacts.contains(name1))
+      assert(handler.getFinalArtifacts.contains(name2))
+      assert(handler.getFinalArtifacts.contains(name3))
+
+      assert(e.getStatus.getCode == Code.INTERNAL)
+      val statusProto = StatusProto.fromThrowable(e)
+      assert(statusProto.getDetailsCount == 1)
+      val details = statusProto.getDetails(0)
+      val info = details.unpack(classOf[ErrorInfo])
+
+      assert(e.getMessage.contains("ARTIFACT_ALREADY_EXISTS"))
+      assert(info.getMetadataMap().get("messageParameters").contains(name1))
+    } finally {
+      handler.forceCleanUp()
+    }
+  }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -53,8 +53,9 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     override def onCompleted(): Unit = {}
   }
 
-  class TestAddArtifactsHandler(responseObserver: StreamObserver[AddArtifactsResponse],
-                                throwIfArtifactExists: Boolean = false)
+  class TestAddArtifactsHandler(
+      responseObserver: StreamObserver[AddArtifactsResponse],
+      throwIfArtifactExists: Boolean = false)
       extends SparkConnectAddArtifactsHandler(responseObserver) {
 
     // Stop the staged artifacts from being automatically deleted
@@ -68,12 +69,11 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
       // Throw if artifact already exists and has different checksum
       // This mocks the behavior of ArtifactManager.addArtifact without comparing the entire file
       if (throwIfArtifactExists
-          && finalArtifacts.contains(artifact.name)
-          && artifact.getCrc != artifactChecksums(artifact.name)) {
+        && finalArtifacts.contains(artifact.name)
+        && artifact.getCrc != artifactChecksums(artifact.name)) {
         throw new SparkRuntimeException(
           "ARTIFACT_ALREADY_EXISTS",
-          Map("normalizedRemoteRelativePath" -> artifact.name)
-        )
+          Map("normalizedRemoteRelativePath" -> artifact.name))
       }
 
       finalArtifacts.append(artifact.name)
@@ -434,7 +434,6 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
     }
   }
 
-
   def addSingleChunkArtifact(
       handler: SparkConnectAddArtifactsHandler,
       sessionKey: SessionKey,
@@ -472,8 +471,8 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
 
   test("All artifacts are added, even if some fail") {
     val promise = Promise[AddArtifactsResponse]()
-    val handler = new TestAddArtifactsHandler(new DummyStreamObserver(promise),
-                                              throwIfArtifactExists = true)
+    val handler =
+      new TestAddArtifactsHandler(new DummyStreamObserver(promise), throwIfArtifactExists = true)
     try {
       val name1 = "jars/dummy1.jar"
       val name2 = "jars/dummy2.jar"

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -267,7 +267,7 @@ class ArtifactManager(session: SparkSession) extends AutoCloseable with Logging 
    * they are from a permanent location.
    */
   private[sql] def addLocalArtifacts(artifacts: Seq[Artifact]): Unit = {
-    val failedArtifactExceptions = ListBuffer[RuntimeException]()
+    val failedArtifactExceptions = ListBuffer[SparkRuntimeException]()
 
     artifacts.foreach { artifact =>
       try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -386,8 +386,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
     checkError(
       exception = ex,
       condition = "ARTIFACT_ALREADY_EXISTS",
-      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"),
-    )
+      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"))
 
     assert(ex.getSuppressed.length == 1)
     assert(ex.getSuppressed.head.isInstanceOf[SparkRuntimeException])
@@ -396,8 +395,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
     checkError(
       exception = suppressed,
       condition = "ARTIFACT_ALREADY_EXISTS",
-      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"),
-    )
+      parameters = Map("normalizedRemoteRelativePath" -> s"jars/${targetPath.toString}"))
 
     // Artifact1 should have been added
     val expectedFile1 = ArtifactManager.artifactRootDirectory

--- a/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/artifact/ArtifactManagerSuite.scala
@@ -357,7 +357,7 @@ class ArtifactManagerSuite extends SharedSparkSession {
     val targetPath2 = Paths.get(artifact2Path)
 
     val classPath1 = copyDir.resolve("Hello.class")
-    val classPath2 = copyDir.resolve("smallJar.jar")
+    val classPath2 = copyDir.resolve("udf_noA.jar")
     assume(artifactPath.resolve("Hello.class").toFile.exists)
     assume(artifactPath.resolve("smallClassFile.class").toFile.exists)
 


### PR DESCRIPTION
<!--
Please read [go/dbr-dev-guides](https://go/dbr-dev-guides/) before creating a pull request against files shared between Databricks Runtime and open-source Apache Spark.
For example, this includes files under the `org.apache.spark` package path.
If in doubt, please reach out to a member of the open-source team for help.
-->

## What changes were proposed in this pull request?

When multiple artifacts are added at once and one of them fails due to an exception (e.g. artifact already exists), the remaining artifacts should still be added instead of returning the error to the client immediately.

<!--
Please fill in changes proposed in this fix.
-->

## How was this patch tested?

Unit test and local testing.

<!--
1. Please explain how this patch was tested. For example: unit tests, integration tests, manual tests)
2. If this patch involves UI changes, please attach a screenshot; otherwise, remove this)
3. Comment `jenkins crosstest` on the PR to trigger a Jenkins/Runbot job which tests DBR's compilation from the universe repository.)
-->

## This PR introduces the following *user-facing* changes

*This section is for [API auditing](http://go/dbr-api-auditing) review.*
<!--
1. You need to document all the user-facing changes for API auditing purpose; otherwise, delete this section and add the `auditing-free` label.
2. Please explain all the user-facing changes such as new APIs/functionalities, correctness/behavior fixes, and improvements that change the result schema or accept new cases.
3. Please clarify the affected versions, the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible. All the user-facing changes need to be approved by the `API Tsars` group before merging.
-->

AFFECTED VERSIONS:

PROBLEM DESCRIPTION:

## Warmfix

<!--
If this PR needs to be cherry-picked to any DBR release branches (e.g. `dbr-branch-10.4`) or DBR RC branches (e.g. `dbr-branch-10.4.6`), please follow the checklist below. If not applicable, remove this section.
-->

- [ ] Your change is a backport targeting at least one maintenance release. You must get your Shiproom Lead's approval for backporting this change. In case your Shiproom is unable to review and you are blocked, please review your backporting changes with Amit Shukla. Please choose the right category for your backporting change.
  - [ ] Critical fixes
  - [ ] UC critical adoption path
  - [ ] Logging changes (Debug, asserts, QPL/NQL)
  - [ ] Test or build infra changes
  - [ ] Other
- [ ] Your PR is a backport making changes (add/remove/modify) to Spark Connect API. If so, please check the following action item:
  - [ ] Server-side API implementation is included in the backport. Not including server-side API implementation alongside proto changes has [caused production bugs](https://docs.google.com/document/d/1Co7E5nRnwQCuUhAa-7S7naZbWNJ1Gk3ozncNmY_gegc/edit?usp=sharing).
- [ ] This PR should be [warmfixed](https://databricks.atlassian.net/wiki/spaces/UN/pages/2583626552/DBR+release+developer+operation+workflow#What-is-a-%E2%80%98warmfix%E2%80%99) into DBR release branch(es)(e.g. `dbr-branch-10.4`) for next un-cut DBR maintenance release. [Instructions](https://databricks.atlassian.net/wiki/spaces/UN/pages/2583626552/DBR+release+developer+operation+workflow#Warmfix)
- [ ] This PR should be considered for [RC Warmfix](https://databricks.atlassian.net/wiki/spaces/UN/pages/2583626552/DBR+release+developer+operation+workflow#What-is-%E2%80%98Warmfix-RC%E2%80%99) for already cut but not shipped maintenance release. [Instructions](https://databricks.atlassian.net/wiki/spaces/UN/pages/2583626552/DBR+release+developer+operation+workflow#RC-Warmfix%2FHotfix)
- [ ] This PR should be considered for [RC Hotfix](https://databricks.atlassian.net/wiki/spaces/UN/pages/2583626552/DBR+release+developer+operation+workflow#What-is-a-%E2%80%98hotfix%E2%80%99) to the current production version. [Instructions](https://databricks.atlassian.net/wiki/spaces/UN/pages/2583626552/DBR+release+developer+operation+workflow#RC-Warmfix%2FHotfix)


## Behavioral Change Information

- [ ] Change is considered a "[Behavioral Change](https://docs.google.com/document/d/1PYOk6kwNyANC5kSUi48ohoNyeAzmWjSpFrsfoJWUcqc/)" and will have a "[BEHAVE jira created](http://go/behavior-change-request)"
- [ ] Change is **NOT** considered a "[Behavioral Change](https://docs.google.com/document/d/1PYOk6kwNyANC5kSUi48ohoNyeAzmWjSpFrsfoJWUcqc/)"

## Release Note Information

- [ ] Change requires a release note (Behavioral changes require one). Please check the checkbox if this PR contains changes that should be mentioned in DBR release notes and if checked make sure a SC Jira ticket is in the PR title what will be used to document the release note.
- [ ] Change does **NOT** require a release note

## Products Affected

If your change is a behavioral change or needs a release note, which product lines are affected

- [ ] All product lines
- [ ] Classic DBR
- [ ] Serverless Generic Compute
- [ ] DBSQL
- [ ] DLT

## Security implications

<!--
This section is to ensure the reviewer evaluates that go/sdr was met for this PR as part of FedRAMP moderate compliance.
-->

_This section is intended for the reviewers of this PR_
Please, make sure you consider the content of "What are the responsibilities of code reviewers?" section of [go/pr-security-review](http://go/pr-security-review)
